### PR TITLE
Add support from Medic - CHT

### DIFF
--- a/dpg-sustainability/en.md
+++ b/dpg-sustainability/en.md
@@ -41,13 +41,12 @@ Sincerely,
 - Quentin Perrot, Chief Product Officer, Zenysis Technologies ([Harmony](https://www.digitalpublicgoods.net/r/harmony)).
 - Kristin Braa, Director, HISP Centre at University of Oslo ([DHIS2](https://www.digitalpublicgoods.net/r/dhis2)).
 - Edward Cable, President/CEO, [The Mifos Initiative](https://mifos.org) ([Mifos X](https://www.digitalpublicgoods.net/r/mifos-x) \| [PH-EE](https://www.digitalpublicgoods.net/r/mifos-payment-hub-ee-ph-ee)).
+- Andra Blaj, Director of Open Technology, [Medic](https://medic.org/) ([Community Health Toolkit](https://www.digitalpublicgoods.net/r/community-health-toolkit)).
 
 
 ---
 
 Supported by:
-
-- Andra Blaj, Director of Open Technology, [Medic](https://medic.org/)([Community Health Toolkit](https://www.digitalpublicgoods.net/r/community-health-toolkit)).
 - TBA
 
 > 📨 Kindly read [this guide](https://github.com/DPGAlliance/dpg-public-letters/blob/main/README.md) to learn how to support this movement and endorse the letter.


### PR DESCRIPTION
Add support from [Medic](https://medic.org/), the steward of the [Community Health Toolkit](https://www.digitalpublicgoods.net/r/community-health-toolkit).  